### PR TITLE
Fix use of EROOT to be compatible with EAPI 7+.

### DIFF
--- a/locale-gen
+++ b/locale-gen
@@ -124,17 +124,17 @@ fi
 
 : "${EROOT:=${EPREFIX}/}"
 if [[ ${EROOT} != "/" ]] ; then
-	einfo "Using locale.gen from ${EROOT}etc/"
+	einfo "Using locale.gen from ${EROOT%/}/etc/"
 fi
 
 if [[ -n ${DESTDIR} ]] ; then
 	DESTDIR="${DESTDIR%/}/"
 	einfo "Building locales in DESTDIR '${DESTDIR}'"
 else
-	DESTDIR=${EROOT}
+	DESTDIR="${EROOT%/}/"
 fi
 
-: "${CONFIG:=${EROOT}etc/locale.gen}"
+: "${CONFIG:=${EROOT%/}/etc/locale.gen}"
 LOCALES=${DESTDIR}usr/share/i18n/locales
 CHARMAPS=${DESTDIR}usr/share/i18n/charmaps
 SUPPORTED=${DESTDIR}usr/share/i18n/SUPPORTED


### PR DESCRIPTION
EROOT no longer has a trailing slash, so replace it with "${EROOT%/}/" to avoid errors such as:

```
/home/oldeman/eessi3/usr/sbin/locale-gen: line 168: /home/oldeman/eessi3usr/bin/localedef: No such file or directory
 * Unable to parse the output of your localedef utility.
 * File a bug about this issue and include the output of 'localedef --help'.
```

in `stage3.log` when bootstrapping Gentoo Prefix.

See also:
https://mgorny.pl/articles/the-ultimate-guide-to-eapi-7.html#d-ed-root-eroot-no-longer-have-a-trailing-slash

Closes: https://bugs.gentoo.org/883457